### PR TITLE
asp.net core 2.0 support

### DIFF
--- a/Sample/Controllers/AccountController.cs
+++ b/Sample/Controllers/AccountController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
@@ -24,19 +24,19 @@ namespace Sample.Controllers
 		private readonly IEmailSender _emailSender;
 		private readonly ISmsSender _smsSender;
 		private readonly ILogger _logger;
-		private readonly string _externalCookieScheme;
+		//private readonly string _externalCookieScheme;
 
 		public AccountController(
 			UserManager<ElasticUser> userManager,
 			SignInManager<ElasticUser> signInManager,
-			IOptions<IdentityCookieOptions> identityCookieOptions,
+			//IOptions<IdentityCookieOptions> identityCookieOptions,
 			IEmailSender emailSender,
 			ISmsSender smsSender,
 			ILoggerFactory loggerFactory)
 		{
 			_userManager = userManager;
 			_signInManager = signInManager;
-			_externalCookieScheme = identityCookieOptions.Value.ExternalCookieAuthenticationScheme;
+			//_externalCookieScheme = identityCookieOptions.Value.ExternalCookieAuthenticationScheme;
 			_emailSender = emailSender;
 			_smsSender = smsSender;
 			_logger = loggerFactory.CreateLogger<AccountController>();
@@ -49,7 +49,7 @@ namespace Sample.Controllers
 		public async Task<IActionResult> Login(string returnUrl = null)
 		{
 			// Clear the existing external cookie to ensure a clean login process
-			await HttpContext.Authentication.SignOutAsync(_externalCookieScheme);
+			//await HttpContext.Authentication.SignOutAsync(_externalCookieScheme);
 
 			ViewData["ReturnUrl"] = returnUrl;
 			return View();

--- a/Sample/Controllers/AccountController.cs
+++ b/Sample/Controllers/AccountController.cs
@@ -24,19 +24,16 @@ namespace Sample.Controllers
 		private readonly IEmailSender _emailSender;
 		private readonly ISmsSender _smsSender;
 		private readonly ILogger _logger;
-		//private readonly string _externalCookieScheme;
-
+		
 		public AccountController(
 			UserManager<ElasticUser> userManager,
 			SignInManager<ElasticUser> signInManager,
-			//IOptions<IdentityCookieOptions> identityCookieOptions,
 			IEmailSender emailSender,
 			ISmsSender smsSender,
 			ILoggerFactory loggerFactory)
 		{
 			_userManager = userManager;
 			_signInManager = signInManager;
-			//_externalCookieScheme = identityCookieOptions.Value.ExternalCookieAuthenticationScheme;
 			_emailSender = emailSender;
 			_smsSender = smsSender;
 			_logger = loggerFactory.CreateLogger<AccountController>();
@@ -48,9 +45,6 @@ namespace Sample.Controllers
 		[AllowAnonymous]
 		public async Task<IActionResult> Login(string returnUrl = null)
 		{
-			// Clear the existing external cookie to ensure a clean login process
-			//await HttpContext.Authentication.SignOutAsync(_externalCookieScheme);
-
 			ViewData["ReturnUrl"] = returnUrl;
 			return View();
 		}

--- a/Sample/Controllers/ManageController.cs
+++ b/Sample/Controllers/ManageController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -19,7 +19,7 @@ namespace Sample.Controllers
     {
         private readonly UserManager<ElasticUser> _userManager;
         private readonly SignInManager<ElasticUser> _signInManager;
-        private readonly string _externalCookieScheme;
+        //private readonly string _externalCookieScheme;
         private readonly IEmailSender _emailSender;
         private readonly ISmsSender _smsSender;
         private readonly ILogger _logger;
@@ -27,14 +27,14 @@ namespace Sample.Controllers
         public ManageController(
           UserManager<ElasticUser> userManager,
           SignInManager<ElasticUser> signInManager,
-          IOptions<IdentityCookieOptions> identityCookieOptions,
+          //IOptions<IdentityCookieOptions> identityCookieOptions,
           IEmailSender emailSender,
           ISmsSender smsSender,
           ILoggerFactory loggerFactory)
         {
             _userManager = userManager;
             _signInManager = signInManager;
-            _externalCookieScheme = identityCookieOptions.Value.ExternalCookieAuthenticationScheme;
+            //_externalCookieScheme = identityCookieOptions.Value.ExternalCookieAuthenticationScheme;
             _emailSender = emailSender;
             _smsSender = smsSender;
             _logger = loggerFactory.CreateLogger<ManageController>();
@@ -292,12 +292,12 @@ namespace Sample.Controllers
                 return View("Error");
             }
             var userLogins = await _userManager.GetLoginsAsync(user);
-            var otherLogins = _signInManager.GetExternalAuthenticationSchemes().Where(auth => userLogins.All(ul => auth.AuthenticationScheme != ul.LoginProvider)).ToList();
+            //var otherLogins = _signInManager.GetExternalAuthenticationSchemes().Where(auth => userLogins.All(ul => auth.AuthenticationScheme != ul.LoginProvider)).ToList();
             ViewData["ShowRemoveButton"] = user.PasswordHash != null || userLogins.Count > 1;
             return View(new ManageLoginsViewModel
             {
                 CurrentLogins = userLogins,
-                OtherLogins = otherLogins
+                //OtherLogins = otherLogins
             });
         }
 
@@ -308,7 +308,7 @@ namespace Sample.Controllers
         public async Task<IActionResult> LinkLogin(string provider)
         {
             // Clear the existing external cookie to ensure a clean login process
-            await HttpContext.Authentication.SignOutAsync(_externalCookieScheme);
+            //await HttpContext.Authentication.SignOutAsync(_externalCookieScheme);
 
             // Request a redirect to the external login provider to link a login for the current user
             var redirectUrl = Url.Action(nameof(LinkLoginCallback), "Manage");
@@ -337,7 +337,7 @@ namespace Sample.Controllers
             {
                 message = ManageMessageId.AddLoginSuccess;
                 // Clear the existing external cookie to ensure a clean login process
-                await HttpContext.Authentication.SignOutAsync(_externalCookieScheme);
+                //await HttpContext.Authentication.SignOutAsync(_externalCookieScheme);
             }
             return RedirectToAction(nameof(ManageLogins), new { Message = message });
         }

--- a/Sample/Controllers/ManageController.cs
+++ b/Sample/Controllers/ManageController.cs
@@ -292,12 +292,15 @@ namespace Sample.Controllers
                 return View("Error");
             }
             var userLogins = await _userManager.GetLoginsAsync(user);
-            //var otherLogins = _signInManager.GetExternalAuthenticationSchemes().Where(auth => userLogins.All(ul => auth.AuthenticationScheme != ul.LoginProvider)).ToList();
+			var otherLoginsTask = _signInManager.GetExternalAuthenticationSchemesAsync();
+			var otherLogins = otherLoginsTask.Result
+								.Where(auth => userLogins.All(ul => auth.Name != ul.LoginProvider)).ToList();
+
             ViewData["ShowRemoveButton"] = user.PasswordHash != null || userLogins.Count > 1;
             return View(new ManageLoginsViewModel
             {
                 CurrentLogins = userLogins,
-                //OtherLogins = otherLogins
+                OtherLogins = otherLogins
             });
         }
 

--- a/Sample/Models/ManageViewModels/ManageLoginsViewModel.cs
+++ b/Sample/Models/ManageViewModels/ManageLoginsViewModel.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http.Authentication;
 using Microsoft.AspNetCore.Identity;
 
@@ -11,6 +12,6 @@ namespace Sample.Models.ManageViewModels
     {
         public IList<UserLoginInfo> CurrentLogins { get; set; }
 
-        public IList<AuthenticationDescription> OtherLogins { get; set; }
+        public IList<AuthenticationScheme> OtherLogins { get; set; }
     }
 }

--- a/Sample/Properties/launchSettings.json
+++ b/Sample/Properties/launchSettings.json
@@ -10,7 +10,6 @@
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
-      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Sample/Properties/launchSettings.json
+++ b/Sample/Properties/launchSettings.json
@@ -10,6 +10,7 @@
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
+      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -12,24 +12,25 @@
     <UserSecretsId>aspnet-Sample-9f77e759-f8cb-4410-8d1a-aed44bde1ecb</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="1.1.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="1.1.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="1.1.0" />
-    <PackageReference Include="NEST" Version="5.2.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.3" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.0.0" />
+    <PackageReference Include="NEST" Version="5.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="1.0.0" />

--- a/Sample/Sample.csproj
+++ b/Sample/Sample.csproj
@@ -16,14 +16,9 @@
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.3" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />

--- a/Sample/Startup.cs
+++ b/Sample/Startup.cs
@@ -80,37 +80,9 @@ namespace Sample
 				options.Lockout.AllowedForNewUsers = true;
 			});
 
-			services.ConfigureApplicationCookie(options => options.LoginPath = "/Account/Login");
-
-			services.AddAuthentication(IdentityConstants.ApplicationScheme)
-				.AddCookie(options => {
-					options.LoginPath = "/Account/LogIn";
-					options.LogoutPath = "/Account/LogOff";
-				});
-
-			// Services used by identity
-			//services.AddAuthentication(options =>
-			//{
-			//	// This is the Default value for ExternalCookieAuthenticationScheme
-			//	options.DefaultAuthenticateScheme = IdentityConstants.ApplicationScheme;
-			//	options.DefaultChallengeScheme = IdentityConstants.ApplicationScheme;
-			//	options.DefaultSignInScheme = IdentityConstants.ApplicationScheme;
-			//});
-
 			services.AddOptions();
 			services.AddDataProtection();
-
-			//services.TryAddSingleton<IdentityMarkerService>();
-			//services.TryAddSingleton<IUserValidator<ElasticUser>, UserValidator<ElasticUser>>();
-			//services.TryAddSingleton<IPasswordValidator<ElasticUser>, PasswordValidator<ElasticUser>>();
-			services.TryAddSingleton<IPasswordHasher<ElasticUser>, PasswordHasher<ElasticUser>>();
-			services.TryAddSingleton<ILookupNormalizer, UpperInvariantLookupNormalizer>();
-			//services.TryAddSingleton<IdentityErrorDescriber>();
-			services.TryAddSingleton<ISecurityStampValidator, SecurityStampValidator<ElasticUser>>();
-			//services.TryAddSingleton<IUserClaimsPrincipalFactory<ElasticUser>, UserClaimsPrincipalFactory<ElasticUser>>();
-			//services.TryAddSingleton<UserManager<ElasticUser>, UserManager<ElasticUser>>();
-			//services.TryAddScoped<SignInManager<ElasticUser>, SignInManager<ElasticUser>>();
-
+			
 			services.AddMvc();
 
 			// Add application services.
@@ -127,7 +99,6 @@ namespace Sample
 			if (env.IsDevelopment())
 			{
 				app.UseDeveloperExceptionPage();
-				app.UseDatabaseErrorPage();
 				app.UseBrowserLink();
 			}
 			else
@@ -136,8 +107,7 @@ namespace Sample
 			}
 
 			app.UseStaticFiles();
-
-			//app.UseIdentity();
+			
 			app.UseAuthentication();
 
 			// Add external authentication middleware below. To configure them please see https://go.microsoft.com/fwlink/?LinkID=532715
@@ -150,66 +120,5 @@ namespace Sample
 			});
 
 		}
-			
-		public class UserClaimsPrincipalFactory<TUser> : IUserClaimsPrincipalFactory<TUser>
-			where TUser : class
-		{
-			public UserClaimsPrincipalFactory(
-				UserManager<TUser> userManager,
-				IOptions<IdentityOptions> optionsAccessor)
-			{
-				if (optionsAccessor?.Value == null)
-				{
-					throw new ArgumentNullException(nameof(optionsAccessor));
-				}
-
-				UserManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
-				Options = optionsAccessor.Value;
-			}
-
-			public UserManager<TUser> UserManager { get; }
-
-			public IdentityOptions Options { get; }
-
-			public virtual async Task<ClaimsPrincipal> CreateAsync(TUser user)
-			{
-				if (user == null)
-				{
-					throw new ArgumentNullException(nameof(user));
-				}
-
-				var userId = await UserManager.GetUserIdAsync(user);
-				var userName = await UserManager.GetUserNameAsync(user);
-
-				//var id = new ClaimsIdentity(Options.Cookies.ApplicationCookieAuthenticationScheme,
-				//	Options.ClaimsIdentity.UserNameClaimType,
-				//	Options.ClaimsIdentity.RoleClaimType);
-
-				var id = new ClaimsIdentity(IdentityConstants.ApplicationScheme);
-
-				id.AddClaim(new Claim(Options.ClaimsIdentity.UserIdClaimType, userId));
-				id.AddClaim(new Claim(Options.ClaimsIdentity.UserNameClaimType, userName));
-				if (UserManager.SupportsUserSecurityStamp)
-				{
-					id.AddClaim(new Claim(Options.ClaimsIdentity.SecurityStampClaimType,
-						await UserManager.GetSecurityStampAsync(user)));
-				}
-				if (UserManager.SupportsUserRole)
-				{
-					var roles = await UserManager.GetRolesAsync(user);
-					foreach (var roleName in roles)
-					{
-						id.AddClaim(new Claim(Options.ClaimsIdentity.RoleClaimType, roleName));
-					}
-				}
-				if (UserManager.SupportsUserClaim)
-				{
-					id.AddClaims(await UserManager.GetClaimsAsync(user));
-				}
-
-				return new ClaimsPrincipal(id);
-			}
-		}
-
 	}
 }

--- a/Sample/Startup.cs
+++ b/Sample/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Identity;
 using System.IO;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.Cookies;
 
 namespace Sample
 {
@@ -68,33 +69,47 @@ namespace Sample
 				return nestClient;
 			});			
 
-			services.AddElasticSearchIdentity<ElasticUser, ElasticRole>();
+			
+
+			services.AddIdentity<ElasticUser, ElasticRole>()
+				.AddElasticsearchIdentity()
+				.AddDefaultTokenProviders();
 
 			services.Configure<IdentityOptions>(options =>
 			{
 				options.Lockout.AllowedForNewUsers = true;
 			});
 
+			services.ConfigureApplicationCookie(options => options.LoginPath = "/Account/Login");
+
+			services.AddAuthentication(IdentityConstants.ApplicationScheme)
+				.AddCookie(options => {
+					options.LoginPath = "/Account/LogIn";
+					options.LogoutPath = "/Account/LogOff";
+				});
+
 			// Services used by identity
-			services.AddAuthentication(options =>
-			{
-				// This is the Default value for ExternalCookieAuthenticationScheme
-				options.SignInScheme = new IdentityCookieOptions().ExternalCookieAuthenticationScheme;
-			});
+			//services.AddAuthentication(options =>
+			//{
+			//	// This is the Default value for ExternalCookieAuthenticationScheme
+			//	options.DefaultAuthenticateScheme = IdentityConstants.ApplicationScheme;
+			//	options.DefaultChallengeScheme = IdentityConstants.ApplicationScheme;
+			//	options.DefaultSignInScheme = IdentityConstants.ApplicationScheme;
+			//});
 
 			services.AddOptions();
 			services.AddDataProtection();
 
-			services.TryAddSingleton<IdentityMarkerService>();
-			services.TryAddSingleton<IUserValidator<ElasticUser>, UserValidator<ElasticUser>>();
-			services.TryAddSingleton<IPasswordValidator<ElasticUser>, PasswordValidator<ElasticUser>>();
+			//services.TryAddSingleton<IdentityMarkerService>();
+			//services.TryAddSingleton<IUserValidator<ElasticUser>, UserValidator<ElasticUser>>();
+			//services.TryAddSingleton<IPasswordValidator<ElasticUser>, PasswordValidator<ElasticUser>>();
 			services.TryAddSingleton<IPasswordHasher<ElasticUser>, PasswordHasher<ElasticUser>>();
 			services.TryAddSingleton<ILookupNormalizer, UpperInvariantLookupNormalizer>();
-			services.TryAddSingleton<IdentityErrorDescriber>();
+			//services.TryAddSingleton<IdentityErrorDescriber>();
 			services.TryAddSingleton<ISecurityStampValidator, SecurityStampValidator<ElasticUser>>();
-			services.TryAddSingleton<IUserClaimsPrincipalFactory<ElasticUser>, UserClaimsPrincipalFactory<ElasticUser>>();
-			services.TryAddSingleton<UserManager<ElasticUser>, UserManager<ElasticUser>>();
-			services.TryAddScoped<SignInManager<ElasticUser>, SignInManager<ElasticUser>>();
+			//services.TryAddSingleton<IUserClaimsPrincipalFactory<ElasticUser>, UserClaimsPrincipalFactory<ElasticUser>>();
+			//services.TryAddSingleton<UserManager<ElasticUser>, UserManager<ElasticUser>>();
+			//services.TryAddScoped<SignInManager<ElasticUser>, SignInManager<ElasticUser>>();
 
 			services.AddMvc();
 
@@ -122,7 +137,8 @@ namespace Sample
 
 			app.UseStaticFiles();
 
-			app.UseIdentity();
+			//app.UseIdentity();
+			app.UseAuthentication();
 
 			// Add external authentication middleware below. To configure them please see https://go.microsoft.com/fwlink/?LinkID=532715
 
@@ -164,9 +180,13 @@ namespace Sample
 
 				var userId = await UserManager.GetUserIdAsync(user);
 				var userName = await UserManager.GetUserNameAsync(user);
-				var id = new ClaimsIdentity(Options.Cookies.ApplicationCookieAuthenticationScheme,
-					Options.ClaimsIdentity.UserNameClaimType,
-					Options.ClaimsIdentity.RoleClaimType);
+
+				//var id = new ClaimsIdentity(Options.Cookies.ApplicationCookieAuthenticationScheme,
+				//	Options.ClaimsIdentity.UserNameClaimType,
+				//	Options.ClaimsIdentity.RoleClaimType);
+
+				var id = new ClaimsIdentity(IdentityConstants.ApplicationScheme);
+
 				id.AddClaim(new Claim(Options.ClaimsIdentity.UserIdClaimType, userId));
 				id.AddClaim(new Claim(Options.ClaimsIdentity.UserNameClaimType, userName));
 				if (UserManager.SupportsUserSecurityStamp)

--- a/Sample/Views/Account/Login.cshtml
+++ b/Sample/Views/Account/Login.cshtml
@@ -59,9 +59,9 @@
         <section>
             <h4>Use another service to log in.</h4>
             <hr />
-            @*@{
-                var loginProviders = SignInManager.GetExternalAuthenticationSchemes().ToList();
-                if (loginProviders.Count == 0)
+            @{
+                var loginProviders = await SignInManager.GetExternalAuthenticationSchemesAsync();
+                if (loginProviders.ToList().Count == 0)
                 {
                     <div>
                         <p>
@@ -77,13 +77,13 @@
                             <p>
                                 @foreach (var provider in loginProviders)
                                 {
-                                    <button type="submit" class="btn btn-default" name="provider" value="@provider.AuthenticationScheme" title="Log in using your @provider.DisplayName account">@provider.AuthenticationScheme</button>
+                                    <button type="submit" class="btn btn-default" name="provider" value="@provider.DisplayName" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
                                 }
                             </p>
                         </div>
                     </form>
                 }
-            }*@
+            }
         </section>
     </div>
 </div>

--- a/Sample/Views/Account/Login.cshtml
+++ b/Sample/Views/Account/Login.cshtml
@@ -1,4 +1,4 @@
-﻿@using System.Collections.Generic
+@using System.Collections.Generic
 @using Microsoft.AspNetCore.Http
 @using Microsoft.AspNetCore.Http.Authentication
 @using AspNetCore.Identity.ElasticSearch
@@ -59,7 +59,7 @@
         <section>
             <h4>Use another service to log in.</h4>
             <hr />
-            @{
+            @*@{
                 var loginProviders = SignInManager.GetExternalAuthenticationSchemes().ToList();
                 if (loginProviders.Count == 0)
                 {
@@ -83,7 +83,7 @@
                         </div>
                     </form>
                 }
-            }
+            }*@
         </section>
     </div>
 </div>

--- a/Sample/Views/Manage/ManageLogins.cshtml
+++ b/Sample/Views/Manage/ManageLogins.cshtml
@@ -1,4 +1,4 @@
-﻿@model ManageLoginsViewModel
+@model ManageLoginsViewModel
 @using Microsoft.AspNetCore.Http.Authentication
 @{
     ViewData["Title"] = "Manage your external logins";
@@ -46,7 +46,7 @@
             <p>
                 @foreach (var provider in Model.OtherLogins)
                 {
-                    <button type="submit" class="btn btn-default" name="provider" value="@provider.AuthenticationScheme" title="Log in using your @provider.DisplayName account">@provider.AuthenticationScheme</button>
+                    <button type="submit" class="btn btn-default" name="provider" value="@provider.Name" title="Log in using your @provider.DisplayName account">@provider.DisplayName</button>
                 }
             </p>
         </div>

--- a/Sample/appsettings.json
+++ b/Sample/appsettings.json
@@ -1,5 +1,5 @@
-﻿{
-  "ElasticSearchUri": "http://localhost:9205",
+{
+  "ElasticSearchUri": "http://localhost:9200",
   "ElasticSearchIdentity": {
     "Index": "test-aspnet-core"
   },

--- a/src/AspNetCore.Identity.ElasticSearch/AspNetCore.Identity.ElasticSearch.csproj
+++ b/src/AspNetCore.Identity.ElasticSearch/AspNetCore.Identity.ElasticSearch.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>    
-    <Version>0.0.4</Version>
+  <PropertyGroup> 
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Version>1.0.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Copyright>The MIT License (MIT)</Copyright>
     <Description>AspNetCore ElasticSearch Identity Provider</Description>
@@ -21,8 +21,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="1.1.1" />
-    <PackageReference Include="NEST" Version="5.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.0.0" />
+    <PackageReference Include="NEST" Version="5.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/AspNetCore.Identity.ElasticSearch/ElasticSearchServiceCollectionExtensions.cs
+++ b/src/AspNetCore.Identity.ElasticSearch/ElasticSearchServiceCollectionExtensions.cs
@@ -12,8 +12,6 @@ namespace AspNetCore.Identity.ElasticSearch
 	{
 		public static IdentityBuilder AddElasticsearchIdentity(this IdentityBuilder identityBuilder)
 		{
-
-			Console.WriteLine();
 			identityBuilder.AddUserStore<ElasticUserStore<ElasticUser, ElasticRole>>();
 			identityBuilder.AddRoleStore<ElasticRole>();
 			identityBuilder.AddUserValidator<UserValidator<ElasticUser>>();
@@ -23,19 +21,6 @@ namespace AspNetCore.Identity.ElasticSearch
 			identityBuilder.AddClaimsPrincipalFactory<UserClaimsPrincipalFactory<ElasticUser>>();
 			identityBuilder.AddErrorDescriber<IdentityErrorDescriber>();
 			
-			//services.AddSingleton(typeof(ElasticUserStore<TUser, TRole>), typeof(ElasticUserStore<TUser, TRole>));
-			//services.AddSingleton(typeof(ElasticRoleStore<TUser, TRole>), typeof(ElasticRoleStore<TUser, TRole>));
-			//services.AddSingleton(typeof(IUserStore<TUser>), sp=> {
-			//	return (IUserStore<TUser>)sp.GetRequiredService(typeof(ElasticUserStore<TUser, TRole>));
-			//});
-			//services.AddSingleton(typeof(IRoleStore<TUser>), sp=> {
-			//	return (IRoleStore<TUser>)sp.GetRequiredService(typeof(ElasticRoleStore<TUser, TRole>));
-			//});
-			//services.AddSingleton(typeof(IRoleClaimStore<TUser>), sp => {
-			//	return (IRoleClaimStore<TUser>)sp.GetRequiredService(typeof(ElasticRoleStore<TUser, TRole>));
-			//});
-
-			//return new IdentityBuilder(typeof(TUser), services);
 			return identityBuilder;
 		}
 

--- a/src/AspNetCore.Identity.ElasticSearch/ElasticSearchServiceCollectionExtensions.cs
+++ b/src/AspNetCore.Identity.ElasticSearch/ElasticSearchServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -10,22 +10,33 @@ namespace AspNetCore.Identity.ElasticSearch
 {
 	public static class ElasticSearchServiceCollectionExtensions
 	{
-		public static IServiceCollection AddElasticSearchIdentity<TUser, TRole>(this IServiceCollection services)
-			where TUser : ElasticUser
-			where TRole : ElasticRole
+		public static IdentityBuilder AddElasticsearchIdentity(this IdentityBuilder identityBuilder)
 		{
-			services.AddSingleton(typeof(ElasticUserStore<TUser, TRole>), typeof(ElasticUserStore<TUser, TRole>));
-			services.AddSingleton(typeof(ElasticRoleStore<TUser, TRole>), typeof(ElasticRoleStore<TUser, TRole>));
-			services.AddSingleton(typeof(IUserStore<TUser>), sp=> {
-				return (IUserStore<TUser>)sp.GetRequiredService(typeof(ElasticUserStore<TUser, TRole>));
-			});
-			services.AddSingleton(typeof(IRoleStore<TUser>), sp=> {
-				return (IRoleStore<TUser>)sp.GetRequiredService(typeof(ElasticRoleStore<TUser, TRole>));
-			});
-			services.AddSingleton(typeof(IRoleClaimStore<TUser>), sp => {
-				return (IRoleClaimStore<TUser>)sp.GetRequiredService(typeof(ElasticRoleStore<TUser, TRole>));
-			});
-			return services;
+
+			Console.WriteLine();
+			identityBuilder.AddUserStore<ElasticUserStore<ElasticUser, ElasticRole>>();
+			identityBuilder.AddRoleStore<ElasticRole>();
+			identityBuilder.AddUserValidator<UserValidator<ElasticUser>>();
+			identityBuilder.AddPasswordValidator<PasswordValidator<ElasticUser>>();
+			identityBuilder.AddSignInManager<SignInManager<ElasticUser>>();
+			identityBuilder.AddUserManager<UserManager<ElasticUser>>();
+			identityBuilder.AddClaimsPrincipalFactory<UserClaimsPrincipalFactory<ElasticUser>>();
+			identityBuilder.AddErrorDescriber<IdentityErrorDescriber>();
+			
+			//services.AddSingleton(typeof(ElasticUserStore<TUser, TRole>), typeof(ElasticUserStore<TUser, TRole>));
+			//services.AddSingleton(typeof(ElasticRoleStore<TUser, TRole>), typeof(ElasticRoleStore<TUser, TRole>));
+			//services.AddSingleton(typeof(IUserStore<TUser>), sp=> {
+			//	return (IUserStore<TUser>)sp.GetRequiredService(typeof(ElasticUserStore<TUser, TRole>));
+			//});
+			//services.AddSingleton(typeof(IRoleStore<TUser>), sp=> {
+			//	return (IRoleStore<TUser>)sp.GetRequiredService(typeof(ElasticRoleStore<TUser, TRole>));
+			//});
+			//services.AddSingleton(typeof(IRoleClaimStore<TUser>), sp => {
+			//	return (IRoleClaimStore<TUser>)sp.GetRequiredService(typeof(ElasticRoleStore<TUser, TRole>));
+			//});
+
+			//return new IdentityBuilder(typeof(TUser), services);
+			return identityBuilder;
 		}
 
 	}

--- a/src/AspNetCore.Identity.ElasticSearch/UserClaimsPrincipalFactory.cs
+++ b/src/AspNetCore.Identity.ElasticSearch/UserClaimsPrincipalFactory.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace AspNetCore.Identity.ElasticSearch
+{
+	public class UserClaimsPrincipalFactory<TUser> : IUserClaimsPrincipalFactory<TUser>
+		where TUser : class
+	{
+		public UserClaimsPrincipalFactory(
+			UserManager<TUser> userManager,
+			IOptions<IdentityOptions> optionsAccessor)
+		{
+			if (optionsAccessor?.Value == null)
+			{
+				throw new ArgumentNullException(nameof(optionsAccessor));
+			}
+
+			UserManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
+			Options = optionsAccessor.Value;
+		}
+
+		public UserManager<TUser> UserManager { get; }
+
+		public IdentityOptions Options { get; }
+
+		public virtual async Task<ClaimsPrincipal> CreateAsync(TUser user)
+		{
+			if (user == null)
+			{
+				throw new ArgumentNullException(nameof(user));
+			}
+
+			var userId = await UserManager.GetUserIdAsync(user);
+			var userName = await UserManager.GetUserNameAsync(user);
+
+			//var id = new ClaimsIdentity(Options.Cookies.ApplicationCookieAuthenticationScheme,
+			//	Options.ClaimsIdentity.UserNameClaimType,
+			//	Options.ClaimsIdentity.RoleClaimType);
+
+			var id = new ClaimsIdentity(IdentityConstants.ApplicationScheme);
+
+			id.AddClaim(new Claim(Options.ClaimsIdentity.UserIdClaimType, userId));
+			id.AddClaim(new Claim(Options.ClaimsIdentity.UserNameClaimType, userName));
+			if (UserManager.SupportsUserSecurityStamp)
+			{
+				id.AddClaim(new Claim(Options.ClaimsIdentity.SecurityStampClaimType,
+					await UserManager.GetSecurityStampAsync(user)));
+			}
+			if (UserManager.SupportsUserRole)
+			{
+				var roles = await UserManager.GetRolesAsync(user);
+				foreach (var roleName in roles)
+				{
+					id.AddClaim(new Claim(Options.ClaimsIdentity.RoleClaimType, roleName));
+				}
+			}
+			if (UserManager.SupportsUserClaim)
+			{
+				id.AddClaims(await UserManager.GetClaimsAsync(user));
+			}
+
+			return new ClaimsPrincipal(id);
+		}
+	}
+}

--- a/tests/AspNetCore.Identity.ElasticSearch.Tests/AspNetCore.Identity.ElasticSearch.Tests.csproj
+++ b/tests/AspNetCore.Identity.ElasticSearch.Tests/AspNetCore.Identity.ElasticSearch.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,12 +16,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="1.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NEST" Version="5.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="NEST" Version="5.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.console" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />

--- a/tests/AspNetCore.Identity.ElasticSearch.Tests/appsettings.json
+++ b/tests/AspNetCore.Identity.ElasticSearch.Tests/appsettings.json
@@ -1,5 +1,5 @@
-﻿{
-  "ElasticSearchUri": "http://localhost:9205",
+{
+  "ElasticSearchUri": "http://localhost:9200",
   "ElasticSearchIdentity": {
     "Index": "test-aspnet-core"
   },


### PR DESCRIPTION
I upgraded the solution to use .net core 2.0 across the board. I don't know that you'll actually want to merge this PR since you may want to keep the current master for others to use. Maybe creating a new repo or branch for it would be better. Your call for sure.

Other than updating the breaking changes, I did make a couple of updates to be aware of. I changed the port number in appsettings.json to use the default Elasticsearch port (9200) since that's what I had and what most people will have in their default setup. I have no idea about the docker support so maybe that's why you had it that way. Update as you see fit.

Another change was to add explicit dependencies to Json.net. It worked without doing this but it was showing warnings in the Dependencies section regarding a version mismatch.

I also removed all of the EntityFramework dependencies since, at least for me, more than half the reason I am using ES for identity is because I'm not using SQL and/or EF for this project. Anyway, feel free to add them back in if you'd like.

Thanks for putting together this project.